### PR TITLE
fix: update regex to parse with whitespace 

### DIFF
--- a/convert.php
+++ b/convert.php
@@ -4,6 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2014 Morris Jobke <hey@morrisjobke.de>
+ * Copyright (c) 2025 Josh Richards <josh.t.richards@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,40 +26,22 @@
  */
 
 /**
- * This code extracts the code comments out of Nextcloud's
+ * This tool extracts the code comments out of Nextcloud's
  * config/config.sample.php and creates an RST document
  */
 
 
 require 'vendor/autoload.php';
 
-function escapeRST($string) {
-	# just replace all \ by \\ if there is no code block present
-	if(strpos($string, '``') === false) {
-		return str_replace('\\', '\\\\', $string);
-	}
+//
+// Defaults
+//
 
-	$parts = explode('``', $string);
-	foreach ($parts as $key => &$part) {
-		# just even parts are outside the code block
-		# example:
-		#
-		# 	Test code: ``$my = $code + 5;`` shows that ...
-		#
-		# The code part has the id 1 and is an odd number
-		if($key%2 == 0) {
-			str_replace('\\', '\\\\', $part);
-		}
-	}
-
-	return implode('``', $parts);
-}
-
-// tag which invokes to copy a config description to the current position
+// tag which can be invoked to copy a config description to the current position
 $COPY_TAG = 'see';
-// file which should be parsed
+// sample config file which should be parsed
 $CONFIG_SAMPLE_FILE = $argv[1] ?? '../server/config/config.sample.php';
-// config documentation file to put content in
+// sample config documentation file update with the processed content
 $OUTPUT_FILE = $argv[2] ?? 'admin_manual/configuration/config_sample_php_parameters.rst';
 
 /**
@@ -71,86 +54,97 @@ $options = getopt(
 	'ht::i::o::',
 	array('help', 'input-file::', 'output-file::', 'tag::'));
 
-if(array_key_exists('h', $options) || array_key_exists('help', $options)) {
+if (array_key_exists('h', $options) || array_key_exists('help', $options)) {
 	$helptext = $argv[0] . " [OPTION] ... (all options are optional)\n\n" .
 	" -h, --help                   Print this help text\n".
 	" -iFILE, --input-file=FILE    Specify the input file (Default: ../server/config/config.sample.php)\n".
 	" -oFILE, --output-file=FILE   Specify the output file (Default: admin_manual/configuration/config_sample_php_parameters.rst)\n".
 	" -tNAME, --tag=NAME           Tag to use for copying a config entry (default: see)\n".
 	"\n";
-	print($helptext);
+	echo $helptext;
 	exit(0);
 }
 
-if(array_key_exists('t', $options)){
+if (array_key_exists('t', $options)){
 	$COPY_TAG = $options['t'];
 } elseif (array_key_exists('tag', $options)) {
 	$COPY_TAG = $options['tag'];
 }
 
-if(array_key_exists('i', $options)){
+if (array_key_exists('i', $options)){
 	$CONFIG_SAMPLE_FILE = $options['i'];
 } elseif (array_key_exists('input-file', $options)) {
 	$CONFIG_SAMPLE_FILE = $options['input-file'];
 }
 
-if(array_key_exists('o', $options)){
+if (array_key_exists('o', $options)){
 	$OUTPUT_FILE = $options['o'];
 } elseif (array_key_exists('output-file', $options)) {
 	$OUTPUT_FILE = $options['output-file'];
 }
 
-// read file
-$docBlock = file_get_contents($CONFIG_SAMPLE_FILE);
+// load sample config file for processing
+$sampleConfig = file_get_contents($CONFIG_SAMPLE_FILE);
 
-// trim everything before this (including itself)
-$start = '$CONFIG = array(';
-if (strpos($docBlock, $start) === false) {
-	$start = '$CONFIG = [';
-	if (strpos($docBlock, $start) === false) {
-		print("Could not find head of config array in config.sample.php\n");
+// verify there is a `$CONFIG` assignment (at least the start of one) in the sample config file
+$start = '$CONFIG = array('; // accept standard array syntax
+if (strpos($sampleConfig, $start) === false) {
+	$start = '$CONFIG = ['; // accept short array syntax
+	if (strpos($sampleConfig, $start) === false) {
+		echo "Could not find head of \$CONFIG array in the sample config file ($SAMPLE_CONFIG_FILE)\n";
 		exit(1);
 	}
 }
-$docBlock = substr($docBlock, strpos($docBlock, $start) + strlen($start));
 
-// trim the end of the config variable
-$end = ');';
-if (strrpos($docBlock, $end) === false) {
-	$end = '];';
-	if (strpos($docBlock, $end) === false) {
-		print("Could not find tail of config array in config.sample.php\n");
+// trim everything above the `$CONFIG` assignment (including itself) from the sample config file
+$sampleConfig = substr($sampleConfig, strpos($sampleConfig, $start) + strlen($start));
+
+// verify there is a complete `$CONFIG` assignment (at least the appearance of one) in the sample config file
+$end = ');'; // accept standard array syntax
+if (strrpos($sampleConfig, $end) === false) {
+	$end = '];'; // accept short array syntax
+	if (strpos($sampleConfig, $end) === false) {
+		print "Could not find tail of \$CONFIG array in the sample config file ($SAMPLE_CONFIG_FILE)\n";
 		exit(1);
 	}
 }
-$docBlock = substr($docBlock, 0, strrpos($docBlock, $end));
 
-// split on '/**'
-$blocks = explode('/**', $docBlock);
+// trim the end of the `$CONFIG` assignment from the sample config file
+$sampleConfig = substr($sampleConfig, 0, strrpos($sampleConfig, $end));
+
+// split on the opener ('/**') to isolate each DocBlock in the sample config file
+$blocks = explode('/**', $sampleConfig);
 
 // output that gets written to the file
-$output = '';
-$outputFirstParagraph = '';
+$outputDefaultSection = ''; // content for first (default) section
+$outputAllOtherSections = ''; // content for all other sections
+
 // array that holds all RST representations of all config options to copy them
-$lookup = array();
+$lookup = [];
 
-// check if the current processed block is the first section (first call sets
+// track if the current processed block is part of the DEFAULT section (first call sets
 // this to true and all other sections to false)
-$isFirstSection = null;
+$isDefaultSection = null;
 
+// process each Docblock
 foreach ($blocks as $block) {
+	$configKey = null; // name of the config key described in the current block (if applicable)
+	$doc = '';
+	$code = '';
+
 	if (trim($block) === '') {
 		continue;
 	}
+
+	// add back the opener to the current block
 	$block = '/**' . $block;
 	$parts = explode(' */', $block);
-	$id = null;
-	$doc = '';
-	$code = '';
-	// there should be exactly two parts after the split - otherwise there are
-	// some mistakes in the parsed block
+	
+	// should be exactly two parts after the split - otherwise there are
+	// mistakes in the parsed block
 	if (count($parts) !== 2) {
-		echo '<h3>Uncommon part count!</h3><pre>';
+		echo "Uncommon part count found in the sample config file ($CONFIG_SAMPLE_FILE)!\n";
+  		echo '<pre>';
 		print_r($parts);
 		echo '</pre>';
 	} else {
@@ -158,55 +152,65 @@ foreach ($blocks as $block) {
 		$code = $parts[1];
 	}
 
-	// this checks if there is a config option below the comment (should be one
-	// if there is a config option or none if the comment is just a heading of
+	// check if there is a config option below the comment (should be one if
+	// there is a config option or none if the comment is just a heading of
 	// the next section
 	preg_match('!^\'([^\']*)\'!m', $block, $matches);
 	if (!in_array(count($matches), array(0, 2))) {
-		echo 'Uncommon matches count<pre>';
+		echo "Uncommon matches count found in the sample config file ($CONFIG_SAMPLE_FILE)!\n";
+		echo '<pre>';
 		print_r($matches);
 		echo '</pre>';
 	}
 
-	// if there are two matches a config option was found -> set it as ID
+	// if there are two matches a config key was found -> set it as configKey
 	if (count($matches) === 2) {
-		$id = $matches[1];
+		$configKey = $matches[1];
 	}
 
 	// parse the doc block
 	$factory  = \phpDocumentor\Reflection\DocBlockFactory::createInstance();
 	$phpdoc = $factory->create($doc);
 
-	// check for tagged elements to replace the tag with the actual config
-	// description
+	// check for tagged elements to replace the tag with the actual config description
+	// NOTE: Only applicable to the ALL_OTHER_SECTIONS
 	$references = $phpdoc->getTagsByName($COPY_TAG);
 	if (!empty($references)) {
 		foreach ($references as $reference) {
 			$name = $reference->getName();
 			if (array_key_exists($name, $lookup)) {
 				// append the element at the current position
-				$output .= $lookup[$name];
+				$outputAllOtherSections .= $lookup[$name];
 			}
 		}
 	}
-
+	
+	// generate RST output for the current block
 	$RSTRepresentation = '';
-
-	// generate RST output
-	if (is_null($id)) {
-		// print heading - no
+	// process section heading content blocks (i.e. categories of related config keys)
+	if (is_null($configKey)) {
+		// use the summary (short description) of the DocBlock as the section heading
 		$heading = $phpdoc->getSummary();
 		$RSTRepresentation .= "\n" . $heading . "\n";
 		$RSTRepresentation .= str_repeat('-', strlen($heading)) . "\n\n";
+		// use the description (long description) of the DocBlock as the section body
 		$longDescription = (string) $phpdoc->getDescription();
 		if (trim($longDescription) !== '') {
 			$RSTRepresentation .= $longDescription . "\n\n";
 		}
-		if($isFirstSection === null) {
-			$isFirstSection = true;
+
+		/** XXX: Not really sure we need to have a DEFAULT_SECTION section versus ALL_OTHER_SECTIONS at this point
+		 * (they all just use their own section header block anyhow so there isn't a real difference between them)
+		 * (only difference I see: the ALL_OTHER_SECTIONS gets it own label: 
+		 *   https://github.com/nextcloud/documentation/blob/4a7cb4b2ed58f11cb7b567d026588a55a506cd31/admin_manual/configuration_server/config_sample_php_parameters.rst?plain=1#L456
+		 * (but also doesn't hurt to keep this for now)
+   		 */
+		if($isDefaultSection === null) {
+			$isDefaultSection = true;
 		} else {
-			$isFirstSection = false;
+			$isDefaultSection = false;
 		}
+	// process individual configKey documentation entry blocks
 	} else {
 		$RSTRepresentation .= "\n" . $id . "\n";
 		$RSTRepresentation .= str_repeat('^', strlen($id)) . "\n\n";
@@ -233,63 +237,99 @@ foreach ($blocks as $block) {
 		// empty line
 		$RSTRepresentation .= "\n";
 
-		$lookup[$id] = $RSTRepresentation;
+		$lookup[$configKey] = $RSTRepresentation;
 	}
 
-	if($isFirstSection) {
-		$outputFirstParagraph .= $RSTRepresentation;
+	// place RST output for current block in the appropriate section
+	if ($isDefaultSection) {
+		$outputDefaultSection .= $RSTRepresentation;
 	} else {
-		$output .= $RSTRepresentation;
+		$outputAllOtherSections .= $RSTRepresentation;
 	}
 }
 
-$configDocumentation = file_get_contents($OUTPUT_FILE);
-$configDocumentationOutput = '';
+// load existing sample config RST document for updating with new (post-processed) block content
+$sampleConfigDoc = file_get_contents($OUTPUT_FILE);
+$sampleConfigDocOutput = '';
 
-$tmp = explode('DEFAULT_SECTION_START', $configDocumentation);
-if(count($tmp) !== 2) {
-	print("There are not exactly one DEFAULT_SECTION_START in the config documentation\n");
+$tmp = explode('DEFAULT_SECTION_START', $sampleConfigDoc);
+if (count($tmp) !== 2) {
+	echo "There are not exactly one DEFAULT_SECTION_START in the config doc ($OUTPUT_FILE)\n";
 	exit(1);
 }
 
-$configDocumentationOutput .= $tmp[0];
+// retain everything before the DEFAULT_SECTION_START
+$sampleConfigDocOutput .= $tmp[0];
+
 // append start placeholder
-$configDocumentationOutput .= "DEFAULT_SECTION_START\n\n";
-// append first paragraph
-$configDocumentationOutput .= $outputFirstParagraph;
+$sampleConfigDocOutput .= "DEFAULT_SECTION_START\n\n";
+
+// append default section
+$sampleConfigDocOutput .= $outputDefaultSection;
+
 // append end placeholder
-$configDocumentationOutput .= "\n.. DEFAULT_SECTION_END";
+$sampleConfigDocOutput .= "\n.. DEFAULT_SECTION_END";
 
 $tmp = explode('DEFAULT_SECTION_END', $tmp[1]);
-if(count($tmp) !== 2) {
-	print("There are not exactly one DEFAULT_SECTION_END in the config documentation\n");
+
+if (count($tmp) !== 2) {
+	echo "There are not exactly one DEFAULT_SECTION_END in the config documentation\n";
 	exit(1);
 }
-// drop the first part (old generated documentation which should be overwritten
-// by  this script) and just process
+
+// drop the first part (old generated documentation which should be overwritten by this script) and just process
 $tmp  = explode('ALL_OTHER_SECTIONS_START', $tmp[1]);
-if(count($tmp) !== 2) {
+if (count($tmp) !== 2) {
 	print("There are not exactly one ALL_OTHER_SECTIONS_START in the config documentation\n");
 	exit(1);
 }
-// append middle part between DEFAULT_SECTION_END and ALL_OTHER_SECTIONS_START
-$configDocumentationOutput .= $tmp[0];
-// append start placeholder
-$configDocumentationOutput .= "ALL_OTHER_SECTIONS_START\n\n";
-// append rest of generated code
-$configDocumentationOutput .= $output;
 
-// drop the first part (old generated documentation which should be overwritten
-// by  this script) and just process
+// retain existing middle part between DEFAULT_SECTION_END and ALL_OTHER_SECTIONS_START
+$sampleConfigDocOutput .= $tmp[0];
+
+// append start placeholder
+$sampleConfigDocOutput .= "ALL_OTHER_SECTIONS_START\n\n";
+
+// append rest of generated code
+$sampleConfigDocOutput .= $outputAllOtherSections;
+
+// drop the first part (old generated documentation which should be overwritten by this script) and just process
 $tmp  = explode('ALL_OTHER_SECTIONS_END', $tmp[1]);
-if(count($tmp) !== 2) {
+if (count($tmp) !== 2) {
 	print("There are not exactly one ALL_OTHER_SECTIONS_END in the config documentation\n");
 	exit(1);
 }
+
 // append end placeholder
-$configDocumentationOutput .= "\n.. ALL_OTHER_SECTIONS_END";
+$sampleConfigDocOutput .= "\n.. ALL_OTHER_SECTIONS_END";
 
-$configDocumentationOutput .= $tmp[1];
+// retain everything after the ALL_OTHERS_SECTION_END
+$sampleConfigDocOutput .= $tmp[1];
 
-// write content to file
-file_put_contents($OUTPUT_FILE, $configDocumentationOutput);
+// save the updated sample config RST document
+file_put_contents($OUTPUT_FILE, $sampleConfigDocOutput);
+
+/**
+ */
+function escapeRST(string $content): string {
+	// just replace all \ by \\ if there is no code block present
+	if(strpos($string, '``') === false) {
+		return str_replace('\\', '\\\\', $string);
+	}
+
+	$parts = explode('``', $string);
+	foreach ($parts as $key => &$part) {
+		/** just even parts are outside the code block
+		* example:
+		*
+		* 	Test code: ``$my = $code + 5;`` shows that ...
+		*
+		* The code part has the id 1 and is an odd number
+		*/
+		if($key%2 == 0) {
+			str_replace('\\', '\\\\', $part);
+		}
+	}
+
+	return implode('``', $parts);
+}

--- a/convert.php
+++ b/convert.php
@@ -155,7 +155,8 @@ foreach ($blocks as $block) {
 	// check if there is a config option below the comment (should be one if
 	// there is a config option or none if the comment is just a heading of
 	// the next section
-	preg_match('!^\'([^\']*)\'!m', $block, $matches);
+	// echo "DEBUG: current block is: $block\n";
+	preg_match('!^\\s\'([^\']*)\'!m', $block, $matches);
 	if (!in_array(count($matches), array(0, 2))) {
 		echo "Uncommon matches count found in the sample config file ($CONFIG_SAMPLE_FILE)!\n";
 		echo '<pre>';
@@ -165,6 +166,7 @@ foreach ($blocks as $block) {
 
 	// if there are two matches a config key was found -> set it as configKey
 	if (count($matches) === 2) {
+		//echo "DEBUG: found configKey: $matches[1]\n";
 		$configKey = $matches[1];
 	}
 
@@ -212,8 +214,8 @@ foreach ($blocks as $block) {
 		}
 	// process individual configKey documentation entry blocks
 	} else {
-		$RSTRepresentation .= "\n" . $id . "\n";
-		$RSTRepresentation .= str_repeat('^', strlen($id)) . "\n\n";
+		$RSTRepresentation .= "\n" . $configKey . "\n";
+		$RSTRepresentation .= str_repeat('^', strlen($configKey)) . "\n\n";
 
 		// mark as literal (code block)
 		$RSTRepresentation .= "\n::\n\n";
@@ -312,12 +314,12 @@ file_put_contents($OUTPUT_FILE, $sampleConfigDocOutput);
 /**
  */
 function escapeRST(string $content): string {
-	// just replace all \ by \\ if there is no code block present
-	if(strpos($string, '``') === false) {
-		return str_replace('\\', '\\\\', $string);
+	// replace all \ by \\ and return if there is no code block present
+	if (strpos($content, '``') === false) {
+		return str_replace('\\', '\\\\', $content);
 	}
 
-	$parts = explode('``', $string);
+	$parts = explode('``', $content);
 	foreach ($parts as $key => &$part) {
 		/** just even parts are outside the code block
 		* example:
@@ -326,7 +328,7 @@ function escapeRST(string $content): string {
 		*
 		* The code part has the id 1 and is an odd number
 		*/
-		if($key%2 == 0) {
+		if ($key % 2 == 0) {
 			str_replace('\\', '\\\\', $part);
 		}
 	}

--- a/convert.php
+++ b/convert.php
@@ -156,7 +156,7 @@ foreach ($blocks as $block) {
 	// there is a config option or none if the comment is just a heading of
 	// the next section
 	// echo "DEBUG: current block is: $block\n";
-	preg_match('!^\\s\'([^\']*)\'!m', $block, $matches);
+	preg_match('!^\\s*\'([^\']*)\'!m', $block, $matches);
 	if (!in_array(count($matches), array(0, 2))) {
 		echo "Uncommon matches count found in the sample config file ($CONFIG_SAMPLE_FILE)!\n";
 		echo '<pre>';


### PR DESCRIPTION
For nextcloud/server#54822

Fixes the regex to handle whitespace (i.e. when our coding standards are applied to the `config.sample.php` ). Remains backwards compatible.

Also some refactoring (new comments, clearer variable names, etc.)

Tested existing config.sample.php as well as the one proposed in nextcloud/server#54822.